### PR TITLE
fix: Use $IncludeConfig in advanced template

### DIFF
--- a/templates/advanced_rsyslog.conf.j2
+++ b/templates/advanced_rsyslog.conf.j2
@@ -77,7 +77,7 @@ $PreserveFQDN on
 #
 # Include all config files in /etc/rsyslog.d/
 #
-include(file="/etc/rsyslog.d/*.conf" mode="optional")
+$IncludeConfig /etc/rsyslog.d/*.conf
 
 ###############
 #### RULES ####


### PR DESCRIPTION
The advanced template was using `include(...)` which causes errors.

---
name: Pull request
about: Describe the proposed change

---

**Describe the change**
A clear and concise description of what the pull request is.

**Testing**
In case a feature was added, how were tests performed?
